### PR TITLE
changed getQRText() from private to public

### DIFF
--- a/lib/TwoFactorAuth.php
+++ b/lib/TwoFactorAuth.php
@@ -159,7 +159,7 @@ class TwoFactorAuth
     /**
      * Builds a string to be encoded in a QR code
      */
-    private function getQRText($label, $secret) 
+    public function getQRText($label, $secret)
     {
         return 'otpauth://totp/' . rawurlencode($label)
             . '?secret=' . rawurlencode($secret)


### PR DESCRIPTION
Changed access modifier for the function getQRText() from private to
public.
This allows for generating the QR Code in different ways (eg pass the
data from getQRText() to the client and have a Javascript Library render
the QR Code)