### PR TITLE
Implement `endroid/qr-code` support

### DIFF
--- a/lib/Providers/Qr/EndroidQrCodeProvider.php
+++ b/lib/Providers/Qr/EndroidQrCodeProvider.php
@@ -1,0 +1,65 @@
+<?php
+namespace RobThree\Auth\Providers\Qr;
+
+use Endroid\QrCode\ErrorCorrectionLevel;
+use Endroid\QrCode\QrCode;
+
+class EndroidQrCodeProvider implements IQRCodeProvider
+{
+    public $bgcolor;
+    public $color;
+    public $margin;
+    public $errorcorrectionlevel;
+
+    public function __construct($bgcolor = 'ffffff', $color = '000000', $margin = 0, $errorcorrectionlevel = 'H')
+    {
+        $this->bgcolor = $this->handleColor($bgcolor);
+        $this->color = $this->handleColor($color);
+        $this->margin = $margin;
+        $this->errorcorrectionlevel = $this->handleErrorCorrectionLevel($errorcorrectionlevel);
+    }
+
+    public function getMimeType()
+    {
+        return 'image/png';
+    }
+
+    public function getQRCodeImage($qrtext, $size)
+    {
+        $qrCode = new QrCode($qrtext);
+        $qrCode->setSize($size);
+
+        $qrCode->setErrorCorrectionLevel($this->errorcorrectionlevel);
+        $qrCode->setMargin($this->margin);
+        $qrCode->setBackgroundColor($this->bgcolor);
+        $qrCode->setForegroundColor($this->color);
+
+        return $qrCode->writeString();
+    }
+
+    private function handleColor($color)
+    {
+        $split = str_split($color, 2);
+        $r = hexdec($split[0]);
+        $g = hexdec($split[1]);
+        $b = hexdec($split[2]);
+
+        return ['r' => $r, 'g' => $g, 'b' => $b, 'a' => 0];
+    }
+
+    private function handleErrorCorrectionLevel($level)
+    {
+        switch ($level) {
+            case 'L':
+                return ErrorCorrectionLevel::LOW();
+            case 'M':
+                return ErrorCorrectionLevel::MEDIUM();
+            case 'Q':
+                return ErrorCorrectionLevel::QUARTILE();
+            case 'H':
+                return ErrorCorrectionLevel::HIGH();
+            default:
+                return ErrorCorrectionLevel::HIGH();
+        }
+    }
+}


### PR DESCRIPTION
I have left out readme changes as it needs updating further, default provider still listed as ImageChartsQRCodeProvider for example.

Usage

```php
$qrProvider = new RobThree\Auth\Providers\Qr\EndroidQrCodeProvider('ffffff', '0000000', 0, 'H');
$tfa = new RobThree\Auth\TwoFactorAuth('My Company', 6, 30, 'sha1', $qrProvider);
```