### PR TITLE
Image support for FreeOTP

### DIFF
--- a/lib/TwoFactorAuth.php
+++ b/lib/TwoFactorAuth.php
@@ -13,6 +13,7 @@ class TwoFactorAuth
     private $period;
     private $digits;
     private $issuer;
+    private $image;
     private $qrcodeprovider = null;
     private $rngprovider = null;
     private $timeprovider = null;
@@ -179,7 +180,8 @@ class TwoFactorAuth
             . '&issuer=' . rawurlencode($this->issuer)
             . '&period=' . intval($this->period)
             . '&algorithm=' . rawurlencode(strtoupper($this->algorithm))
-            . '&digits=' . intval($this->digits);
+            . '&digits=' . intval($this->digits)
+            . ($this->image != '' ? '&image=' . rawurlencode($this->image) : '');
     }
 
     private function base32Decode($value)
@@ -253,4 +255,17 @@ class TwoFactorAuth
         }
         return $this->timeprovider;
     }
+
+    /**
+      * Set the image url used by FreeOTP
+    */
+    public function setImage($image)
+    {
+        $ext = explode(".", $image);
+        //Image must be PNG
+        if (strtolower(end($ext)) == "png") {
+            $this->image = $image;
+        }
+    }    
+
 }


### PR DESCRIPTION
#### Feature added

Added Image support for FreeOPT as explained on this StackOverflow answer: https://stackoverflow.com/a/50410063

#### Feature test

Feature tested on FreeOTP and works as expected. Also tested on Microsoft Authenticator, Authy and Google Authenticator to check that still works on authenticators that do not suport the image parameter.

Test were made on Android versions only