### PR TITLE
🐛 fix unthrowable exception

### DIFF
--- a/lib/Providers/Time/HttpTimeProvider.php
+++ b/lib/Providers/Time/HttpTimeProvider.php
@@ -45,10 +45,10 @@ class HttpTimeProvider implements ITimeProvider
                 if (strcasecmp(substr($h, 0, 5), 'Date:') === 0)
                     return \DateTime::createFromFormat($this->expectedtimeformat, trim(substr($h,5)))->getTimestamp();
             }
-            throw new \TimeException(sprintf('Unable to retrieve time from %s (Invalid or no "Date:" header found)', $this->url));
+            throw new \Exception('Invalid or no "Date:" header found');
+        } catch (\Exception $ex) {
+            throw new TimeException(sprintf('Unable to retrieve time from %s (%s)', $this->url, $ex->getMessage()));
         }
-        catch (Exception $ex) {
-            throw new \TimeException(sprintf('Unable to retrieve time from %s (%s)', $this->url, $ex->getMessage()));
-        }
+
     }
 }

--- a/lib/Providers/Time/TimeException.php
+++ b/lib/Providers/Time/TimeException.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace RobThree\Auth\Providers\Time;
+
 use RobThree\Auth\TwoFactorAuthException;
 
 class TimeException extends TwoFactorAuthException {}


### PR DESCRIPTION
In reviewing the code structure, I noticed this problem.

I think the catch was aiming for the base `Exception` class but because of the namespace of the HttpTimeProvider class, it would never have caught.

Adding the `\` to make it catch, means that the exception in case of no return can have a shorter message to avoid duplicating the desired parts of the message.

I also added the namespace to TimeException for completeness.