### PR TITLE
Increase leniency to reduce test flakiness

### DIFF
--- a/tests/TwoFactorAuthTest.php
+++ b/tests/TwoFactorAuthTest.php
@@ -63,7 +63,7 @@ class TwoFactorAuthTest extends TestCase
             new \RobThree\Auth\Providers\Time\HttpTimeProvider(),                        // Uses google.com by default
             new \RobThree\Auth\Providers\Time\HttpTimeProvider('https://github.com'),
             new \RobThree\Auth\Providers\Time\HttpTimeProvider('https://yahoo.com'),
-        ), 15);
+        ), 20);
         $this->noAssertionsMade();
     }
 

--- a/tests/TwoFactorAuthTest.php
+++ b/tests/TwoFactorAuthTest.php
@@ -56,13 +56,14 @@ class TwoFactorAuthTest extends TestCase
     public function testEnsureAllTimeProvidersReturnCorrectTime()
     {
         $tfa = new TwoFactorAuth('Test', 6, 30, 'sha1');
+        // We increase leniency to ensureCorrectTime to avoid flakiness within GitHub actions test runner
         $tfa->ensureCorrectTime(array(
             new \RobThree\Auth\Providers\Time\NTPTimeProvider(),                         // Uses pool.ntp.org by default
             //new \RobThree\Auth\Providers\Time\NTPTimeProvider('time.google.com'),      // Somehow time.google.com and time.windows.com make travis timeout??
             new \RobThree\Auth\Providers\Time\HttpTimeProvider(),                        // Uses google.com by default
             new \RobThree\Auth\Providers\Time\HttpTimeProvider('https://github.com'),
             new \RobThree\Auth\Providers\Time\HttpTimeProvider('https://yahoo.com'),
-        ));
+        ), 15);
         $this->noAssertionsMade();
     }
 


### PR DESCRIPTION
Increasing the leniency of the test from 5 seconds to 20 seconds seems to reduce the flakiness of the test, having it pass much more consistently.

Closes #69