### PR TITLE
Remove using https://github.com as HttpTimeProvider test source

### DIFF
--- a/tests/TwoFactorAuthTest.php
+++ b/tests/TwoFactorAuthTest.php
@@ -60,7 +60,7 @@ class TwoFactorAuthTest extends TestCase
             new \RobThree\Auth\Providers\Time\NTPTimeProvider(),                         // Uses pool.ntp.org by default
             //new \RobThree\Auth\Providers\Time\NTPTimeProvider('time.google.com'),      // Somehow time.google.com and time.windows.com make travis timeout??
             new \RobThree\Auth\Providers\Time\HttpTimeProvider(),                        // Uses google.com by default
-            new \RobThree\Auth\Providers\Time\HttpTimeProvider('https://github.com'),
+            //new \RobThree\Auth\Providers\Time\HttpTimeProvider('https://github.com'),  // github.com will periodically report times that are off by more than 5 sec
             new \RobThree\Auth\Providers\Time\HttpTimeProvider('https://yahoo.com'),
         ));
         $this->noAssertionsMade();


### PR DESCRIPTION
An alternative to #73 

Closes #69

The flakiness of this test is entirely due to the response coming back from `https://github.com` being off from the system clock. I am able to locally reproduce this flakiness and get test suite failures decently regularly, and on disabling github.com, the test suite passes consistently.