### PR TITLE
Fix compatibility with endroid/qr-code 4

### DIFF
--- a/.github/workflows/test-endroid.yml
+++ b/.github/workflows/test-endroid.yml
@@ -1,0 +1,46 @@
+name: Test Endroid QR Code Provider
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: ['8.0', '8.1']
+        endroid-version: ["^4"]
+        include:
+        - php-version: 5.6
+          # earliest supported version
+          endroid-version: 2.2.1
+        - php-version: 7.0
+          endroid-version: 2.5.1
+        - php-version: 7.1
+          # this version is 7.1+
+          endroid-version: 3.0.0
+        - php-version: 7.2
+          # all later versions are 7.3+
+          endroid-version: 3.5.9
+        - php-version: 7.3
+          endroid-version: 3.9.7
+        - php-version: 7.4
+          endroid-version: 4.0.0
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+        tools: composer
+        coverage: xdebug
+        ini-values: error_reporting=E_ALL
+
+    - uses: ramsey/composer-install@v1
+
+    - run: composer require endroid/qrcode:${{ matrix.endroid-version }}
+
+    - run: composer test testsDependency/EndroidQRCodeTest.php

--- a/lib/Providers/Qr/EndroidQrCodeProvider.php
+++ b/lib/Providers/Qr/EndroidQrCodeProvider.php
@@ -1,8 +1,14 @@
 <?php
 namespace RobThree\Auth\Providers\Qr;
 
+use Endroid\QrCode\Color\Color;
 use Endroid\QrCode\ErrorCorrectionLevel;
+use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelHigh;
+use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelLow;
+use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelMedium;
+use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelQuartile;
 use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Writer\PngWriter;
 
 class EndroidQrCodeProvider implements IQRCodeProvider
 {
@@ -11,8 +17,12 @@ class EndroidQrCodeProvider implements IQRCodeProvider
     public $margin;
     public $errorcorrectionlevel;
 
+    protected $endroid4 = false;
+
     public function __construct($bgcolor = 'ffffff', $color = '000000', $margin = 0, $errorcorrectionlevel = 'H')
     {
+        $this->endroid4 = method_exists(QrCode::class, 'create');
+
         $this->bgcolor = $this->handleColor($bgcolor);
         $this->color = $this->handleColor($color);
         $this->margin = $margin;
@@ -26,7 +36,12 @@ class EndroidQrCodeProvider implements IQRCodeProvider
 
     public function getQRCodeImage($qrtext, $size)
     {
-        return $this->qrCodeInstance($qrtext, $size)->writeString();
+        if (!$this->endroid4) {
+            return $this->qrCodeInstance($qrtext, $size)->writeString();
+        }
+
+        $writer = new PngWriter();
+        return $writer->write($this->qrCodeInstance($qrtext, $size))->getString();
     }
 
     protected function qrCodeInstance($qrtext, $size)
@@ -49,22 +64,21 @@ class EndroidQrCodeProvider implements IQRCodeProvider
         $g = hexdec($split[1]);
         $b = hexdec($split[2]);
 
-        return ['r' => $r, 'g' => $g, 'b' => $b, 'a' => 0];
+        return $this->endroid4 ? new Color($r, $g, $b, 0) : ['r' => $r, 'g' => $g, 'b' => $b, 'a' => 0];
     }
 
     private function handleErrorCorrectionLevel($level)
     {
         switch ($level) {
             case 'L':
-                return ErrorCorrectionLevel::LOW();
+                return $this->endroid4 ? new ErrorCorrectionLevelLow() : ErrorCorrectionLevel::LOW();
             case 'M':
-                return ErrorCorrectionLevel::MEDIUM();
+                return $this->endroid4 ? new ErrorCorrectionLevelMedium() : ErrorCorrectionLevel::MEDIUM();
             case 'Q':
-                return ErrorCorrectionLevel::QUARTILE();
+                return $this->endroid4 ? new ErrorCorrectionLevelQuartile() : ErrorCorrectionLevel::QUARTILE();
             case 'H':
-                return ErrorCorrectionLevel::HIGH();
             default:
-                return ErrorCorrectionLevel::HIGH();
+                return $this->endroid4 ? new ErrorCorrectionLevelHigh() : ErrorCorrectionLevel::HIGH();
         }
     }
 }

--- a/lib/Providers/Qr/EndroidQrCodeWithLogoProvider.php
+++ b/lib/Providers/Qr/EndroidQrCodeWithLogoProvider.php
@@ -1,8 +1,8 @@
 <?php
 namespace RobThree\Auth\Providers\Qr;
 
-use Endroid\QrCode\ErrorCorrectionLevel;
-use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Logo\Logo;
+use Endroid\QrCode\Writer\PngWriter;
 
 class EndroidQrCodeWithLogoProvider extends EndroidQrCodeProvider
 {
@@ -20,13 +20,33 @@ class EndroidQrCodeWithLogoProvider extends EndroidQrCodeProvider
         $this->logoSize = (array)$size;
     }
 
+    public function getQRCodeImage($qrtext, $size)
+    {
+        if (!$this->endroid4) {
+            return $this->qrCodeInstance($qrtext, $size)->writeString();
+        }
+
+        $logo = null;
+        if ($this->logoPath) {
+            $logo = Logo::create($this->logoPath);
+            if ($this->logoSize) {
+                $logo->setResizeToWidth($this->logoSize[0]);
+                if (isset($this->logoSize[1])) {
+                    $logo->setResizeToHeight($this->logoSize[1]);
+                }
+            }
+        }
+        $writer = new PngWriter();
+        return $writer->write($this->qrCodeInstance($qrtext, $size), $logo)->getString();
+    }
+
     protected function qrCodeInstance($qrtext, $size) {
         $qrCode = parent::qrCodeInstance($qrtext, $size);
 
-        if ($this->logoPath) {
+        if (!$this->endroid4 && $this->logoPath) {
             $qrCode->setLogoPath($this->logoPath);
             if ($this->logoSize) {
-                $qrCode->setLogoSize($this->logoSize[0], $this->logoSize[1]);
+                $qrCode->setLogoSize($this->logoSize[0], isset($this->logoSize[1]) ? $this->logoSize[1] : null);
             }
         }
 

--- a/testsDependency/EndroidQRCodeTest.php
+++ b/testsDependency/EndroidQRCodeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TestsDependency;
+
+use PHPUnit\Framework\TestCase;
+use RobThree\Auth\TwoFactorAuth;
+use RobThree\Auth\Providers\Qr\EndroidQrCodeProvider;
+use RobThree\Auth\Providers\Qr\HandlesDataUri;
+
+class EndroidQRCodeTest extends TestCase
+{
+    use HandlesDataUri;
+
+    public function testDependency()
+    {
+        $qr = new EndroidQrCodeProvider();
+        $tfa = new TwoFactorAuth('Test&Issuer', 6, 30, 'sha1', $qr);
+        $data = $this->DecodeDataUri($tfa->getQRCodeImageAsDataUri('Test&Label', 'VMR466AB62ZBOKHE'));
+        $this->assertEquals('image/png', $data['mimetype']);
+        $this->assertEquals('base64', $data['encoding']);
+        $this->assertNotEmpty($data['data']);
+
+    }
+}


### PR DESCRIPTION
Closes #82

This PR adds compatibility with `endroid/qr-code:^4` while maintaining support for older versions.

Test code:
```
<?php

use RobThree\Auth\Providers\Qr\EndroidQrCodeProvider;
use RobThree\Auth\Providers\Qr\EndroidQrCodeWithLogoProvider;

require_once(__DIR__ . '/vendor/autoload.php');

$filename = method_exists(\Endroid\QrCode\QrCode::class, 'create') ? 'test2.png' : 'test1.png';

$provider = new EndroidQrCodeProvider();
file_put_contents(__DIR__ . '/' . $filename, $provider->getQRCodeImage('foobar', 80));

$provider2 = new EndroidQrCodeWithLogoProvider();
$provider2->setLogo(__DIR__ . '/logo.jpeg', [30, 30]);
file_put_contents(__DIR__ . '/logo-' . $filename, $provider2->getQRCodeImage('foobar', 80));
```

`logo.jpeg`:
![logo](https://user-images.githubusercontent.com/1845314/144257988-ff617520-9bf1-48f5-9a03-bdfc8dbfc973.jpeg)

`endroid/qr-code:^3` results:
![test1](https://user-images.githubusercontent.com/1845314/144255578-3e6997fe-08f0-41fa-b04e-4eda93f97a6f.png)

![logo-test1](https://user-images.githubusercontent.com/1845314/144258042-d479f896-d065-445c-857b-05b1b8266deb.png)

`endroid/qr-code:^4` result:
![test2](https://user-images.githubusercontent.com/1845314/144255621-b8d8bf8c-e206-4b41-b9bd-1fd4ddd5986c.png)

![logo-test2](https://user-images.githubusercontent.com/1845314/144258058-339dff13-bbb1-4e68-9355-e418920fe4da.png)