### PR TITLE
Catch deprecations as part of test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         php-version: ${{ matrix.php-version }}
         tools: composer
         coverage: xdebug
+        ini-values: error_reporting=E_ALL
 
     - uses: ramsey/composer-install@v1
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
+         convertDeprecationsToExceptions="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"


### PR DESCRIPTION
From https://github.com/RobThree/TwoFactorAuth/pull/83#issuecomment-983686478, this PR enables failing tests if they throw deprecations. This required updating the CI pipeline as the `shivammathur/setup-php@v2` does `error_reporting=E_ALL | ~E_STRICT | ~E_DEPRECATION` by default for PHP 8+ (ref: https://github.com/shivammathur/setup-php/issues/450) as well as updating configuration for phpunit to convert deprecations into errors.

No existing tests fail from this change.