### PR TITLE
Exclude useless files from dist archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+/.github/ export-ignore
+/demo/ export-ignore
+/docs/ export-ignore
+/tests/ export-ignore
+/testsDependency/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/logo.png export-ignore
+/multifactorauthforeveryone.png export-ignore
+/phpstan.neon export-ignore
+/phpunit.xml export-ignore
+/TwoFactorAuth.phpproj export-ignore
+/TwoFactorAuth.sln export-ignore
+

--- a/composer.json
+++ b/composer.json
@@ -61,20 +61,5 @@
         "test": [
             "XDEBUG_MODE=coverage phpunit"
         ]
-    },
-    "archive": {
-        "exclude": [
-            "/.github/",
-            "/demo/",
-            "/docs/",
-            "/tests/",
-            "/testsDependency/",
-            "/.gitignore",
-            "/logo.png",
-            "/multifactorauthforeveryone.png",
-            "/phpunit.xml",
-            "/TwoFactorAuth.phpproj",
-            "/TwoFactorAuth.sln"
-        ]
     }
 }


### PR DESCRIPTION
Archives fetched from packagist are built by Github (see https://github.com/composer/packagist/issues/1364#issuecomment-1446255498). To exclude files from them, rules should be placed in `.gitattributes`.