### PR TITLE
Change default QR Code provider to EndroidQRCodeProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ PHP library for [two-factor (or multi-factor) authentication](http://en.wikipedi
 ## Requirements
 
 * Requires PHP version >=8.1
-* [cURL](http://php.net/manual/en/book.curl.php) when using the provided `QRServerProvider` (default), `ImageChartsQRCodeProvider` or `QRicketProvider` but you can also provide your own QR-code provider.
+* [endroid/qr-code](https://github.com/endroid/qr-code) when using the provided `EndroidQrCodeProvider` (default) or `EndroidQrCodeWithLogoProvider`.
 * [random_bytes()](http://php.net/manual/en/function.random-bytes.php), [OpenSSL](http://php.net/manual/en/book.openssl.php) or [Hash](http://php.net/manual/en/book.hash.php) depending on which built-in RNG you use (TwoFactorAuth will try to 'autodetect' and use the best available); however: feel free to provide your own (CS)RNG.
 
 Optionally, you may need:
 
+* [cURL](http://php.net/manual/en/book.curl.php) when using the provided `QRServerProvider` (default), `ImageChartsQRCodeProvider` or `QRicketProvider` but you can also provide your own QR-code provider.
 * [sockets](https://www.php.net/manual/en/book.sockets.php) if you are using `NTPTimeProvider`
-* [endroid/qr-code](https://github.com/endroid/qr-code) if using `EndroidQrCodeProvider` or `EndroidQrCodeWithLogoProvider`.
 * [bacon/bacon-qr-code](https://github.com/Bacon/BaconQrCode) if using `BaconQrCodeProvider`.
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "source": "https://github.com/RobThree/TwoFactorAuth"
     },
     "require": {
-        "php": ">=8.1.0"
+        "php": ">=8.1.0",
+        "endroid/qr-code": "Needed for EndroidQrCodeProvider"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",
@@ -35,8 +36,7 @@
         "phpstan/phpstan": "^1.9"
     },
     "suggest": {
-        "bacon/bacon-qr-code": "Needed for BaconQrCodeProvider provider",
-        "endroid/qr-code": "Needed for EndroidQrCodeProvider"
+        "bacon/bacon-qr-code": "Needed for BaconQrCodeProvider provider"
     },
     "autoload": {
         "psr-4": {

--- a/docs/qr-codes.md
+++ b/docs/qr-codes.md
@@ -20,7 +20,7 @@ You can also specify a size as a third argument which is 200 by default.
 
 ## Online Providers
 
-[QRServerProvider](qr-codes/qr-server.html) (default)
+[QRServerProvider](qr-codes/qr-server.html)
 
 [ImageChartsQRCodeProvider](qr-codes/image-charts.html)
 
@@ -28,7 +28,7 @@ You can also specify a size as a third argument which is 200 by default.
 
 ## Offline Providers
 
-[EndroidQrCodeProvider](qr-codes/endroid.html) and EndroidQrCodeWithLogoProvider
+[EndroidQrCodeProvider](qr-codes/endroid.html) and EndroidQrCodeWithLogoProvider (default)
 
 [BaconQRCodeProvider](qr-codes/bacon.html)
 

--- a/lib/TwoFactorAuth.php
+++ b/lib/TwoFactorAuth.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace RobThree\Auth;
 
+use RobThree\Auth\Providers\Qr\EndroidQrCodeProvider;
 use RobThree\Auth\Providers\Qr\IQRCodeProvider;
-use RobThree\Auth\Providers\Qr\QRServerProvider;
 use RobThree\Auth\Providers\Rng\CSRNGProvider;
 use RobThree\Auth\Providers\Rng\HashRNGProvider;
 use RobThree\Auth\Providers\Rng\IRNGProvider;
@@ -169,7 +169,7 @@ class TwoFactorAuth
     {
         // Set default QR Code provider if none was specified
         if (null === $this->qrcodeprovider) {
-            return $this->qrcodeprovider = new QRServerProvider();
+            return $this->qrcodeprovider = new EndroidQrCodeProvider();
         }
         return $this->qrcodeprovider;
     }


### PR DESCRIPTION
Optionally (and preferably) this PR can be used instead of https://github.com/RobThree/TwoFactorAuth/pull/105 to fix issue https://github.com/RobThree/TwoFactorAuth/issues/104

This PR chagnes the default QR code provider to the Endroid one.