### PR TITLE
Fix docs: Construct new TwoFactorAuth-class

### DIFF
--- a/docs/optional-configuration.md
+++ b/docs/optional-configuration.md
@@ -7,15 +7,15 @@ title: Optional Configuration
 
 The instance (`new TwoFactorAuth()`) can only be configured by the constructor with the following optional arguments
 
-Argument          | Default value | Use
-------------------|---------------|-----
-`$issuer`         | `null`        | Will be displayed in the users app as the default issuer name when using QR code to import the secret
-`$digits`         | `6`           | The number of digits the resulting codes will be
-`$period`         | `30`          | The number of seconds a code will be valid
-`$algorithm`      | `'sha1'`      | The algorithm used (one of `sha1`, `sha256`, `sha512`, `md5`)
-`$qrcodeprovider` | `null`        | QR-code provider
-`$rngprovider`    | `null`        | Random Number Generator provider
-`$timeprovider`   | `null`        | Time provider
+Argument          | Default value     | Use
+------------------|-------------------|-----
+`$issuer`         | `null`            | Will be displayed in the users app as the default issuer name when using QR code to import the secret
+`$digits`         | `6`               | The number of digits the resulting codes will be
+`$period`         | `30`              | The number of seconds a code will be valid
+`$algorithm`      | `Algorithm::Sha1` | The algorithm used (one of `Algorithm::Sha1`, `Algorithm::Sha256`, `Algorithm::Sha512`, `Algorithm::md5`)
+`$qrcodeprovider` | `null`            | QR-code provider
+`$rngprovider`    | `null`            | Random Number Generator provider
+`$timeprovider`   | `null`            | Time provider
 
 **Note:** the default values for `$digits`, `$period`, and `$algorithm` provide the widest variety of support amongst common authenticator apps such as Google Authenticator. If you choose to use different values for these arguments you will likely have to instruct your users to use a specific app which supports your chosen configuration.
 

--- a/docs/optional-configuration.md
+++ b/docs/optional-configuration.md
@@ -12,7 +12,7 @@ Argument          | Default value     | Use
 `$issuer`         | `null`            | Will be displayed in the users app as the default issuer name when using QR code to import the secret
 `$digits`         | `6`               | The number of digits the resulting codes will be
 `$period`         | `30`              | The number of seconds a code will be valid
-`$algorithm`      | `Algorithm::Sha1` | The algorithm used (one of `Algorithm::Sha1`, `Algorithm::Sha256`, `Algorithm::Sha512`, `Algorithm::md5`)
+`$algorithm`      | `Algorithm::Sha1` | The algorithm used (one of `Algorithm::Sha1`, `Algorithm::Sha256`, `Algorithm::Sha512`, `Algorithm::Md5`)
 `$qrcodeprovider` | `null`            | QR-code provider
 `$rngprovider`    | `null`            | Random Number Generator provider
 `$timeprovider`   | `null`            | Time provider

--- a/docs/qr-codes.md
+++ b/docs/qr-codes.md
@@ -48,6 +48,7 @@ If you do not want to use the default QR code provider, you can specify the one 
 
 ```php
 use RobThree\Auth\TwoFactorAuth;
+use RobThree\Auth\Algorithm;
 
 $qrCodeProvider = new YourChosenProvider();
 
@@ -55,7 +56,7 @@ $tfa = new TwoFactorAuth(
 	null,
 	6,
 	30,
-	'sha1',
+	Algorithm::Sha1,
 	$qrCodeProvider
 );
 ```

--- a/docs/qr-codes.md
+++ b/docs/qr-codes.md
@@ -20,19 +20,19 @@ You can also specify a size as a third argument which is 200 by default.
 
 ## Online Providers
 
-[QRServerProvider](qr-codes/qr-server.html) (default)
+[QRServerProvider](qr-codes/qr-server.md) (default)
 
 **Warning:** Whilst it is the default, this provider is not suggested for applications where absolute security is needed, because it uses an external service for the QR code generation. You can make use of the included offline providers listed below which generate locally.
 
-[ImageChartsQRCodeProvider](qr-codes/image-charts.html)
+[ImageChartsQRCodeProvider](qr-codes/image-charts.md)
 
-[QRicketProvider](qr-codes/qrickit.html)
+[QRicketProvider](qr-codes/qrickit.md)
 
 ## Offline Providers
 
-[EndroidQrCodeProvider](qr-codes/endroid.html) and EndroidQrCodeWithLogoProvider
+[EndroidQrCodeProvider](qr-codes/endroid.md) and EndroidQrCodeWithLogoProvider
 
-[BaconQRCodeProvider](qr-codes/bacon.html)
+[BaconQRCodeProvider](qr-codes/bacon.md)
 
 **Note:** offline providers may have additional PHP requirements in order to function, you should study what is required before trying to make use of them.
 

--- a/docs/qr-codes.md
+++ b/docs/qr-codes.md
@@ -50,14 +50,12 @@ If you do not want to use the default QR code provider, you can specify the one 
 use RobThree\Auth\TwoFactorAuth;
 use RobThree\Auth\Algorithm;
 
-$qrCodeProvider = new YourChosenProvider();
-
 $tfa = new TwoFactorAuth(
 	null,
 	6,
 	30,
 	Algorithm::Sha1,
-	$qrCodeProvider
+	YourChosenProvider: $qrCodeProvider
 );
 ```
 

--- a/docs/qr-codes.md
+++ b/docs/qr-codes.md
@@ -48,14 +48,10 @@ If you do not want to use the default QR code provider, you can specify the one 
 
 ```php
 use RobThree\Auth\TwoFactorAuth;
-use RobThree\Auth\Algorithm;
 
 $tfa = new TwoFactorAuth(
-	null,
-	6,
-	30,
-	Algorithm::Sha1,
-	YourChosenProvider: $qrCodeProvider
+	issuer: "Your Company Or App Name",
+ 	qrcodeprovider: $qrCodeProvider
 );
 ```
 

--- a/docs/qr-codes.md
+++ b/docs/qr-codes.md
@@ -49,6 +49,8 @@ If you do not want to use the default QR code provider, you can specify the one 
 ```php
 use RobThree\Auth\TwoFactorAuth;
 
+$qrCodeProvider = new YourChosenProvider();
+
 $tfa = new TwoFactorAuth(
 	issuer: "Your Company Or App Name",
  	qrcodeprovider: $qrCodeProvider


### PR DESCRIPTION
Hey, 
your documentation to create a new object of the TwoFactorAuth class is wrong. 
A single string like "sha1" is not enough; expected is an argument of Algorithm.