### PR TITLE
Fix issue #114 (Support for EndroidQR v5)

### DIFF
--- a/.github/workflows/test-endroid.yml
+++ b/.github/workflows/test-endroid.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.1', '8.2']
-        endroid-version: ["^4"]
+        endroid-version: ["^3","^4","^5"]
 
     steps:
     - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
 
     - uses: ramsey/composer-install@v2
 
-    - run: composer require endroid/qrcode:${{ matrix.endroid-version }}
+    - run: composer require endroid/qrcode:${{ matrix.endroid-version }} -W
 
     - run: composer lint-ci
     - run: composer test testsDependency/EndroidQRCodeTest.php

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "source": "https://github.com/RobThree/TwoFactorAuth"
     },
     "require": {
-        "php": ">=8.1.0"
+        "php": ">=8.1.0",
+        "endroid/qr-code": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "source": "https://github.com/RobThree/TwoFactorAuth"
     },
     "require": {
-        "php": ">=8.1.0",
-        "endroid/qr-code": "^5.0"
+        "php": ">=8.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/lib/Providers/Qr/EndroidQrCodeProvider.php
+++ b/lib/Providers/Qr/EndroidQrCodeProvider.php
@@ -26,9 +26,12 @@ class EndroidQrCodeProvider implements IQRCodeProvider
 
     protected $endroid4 = false;
 
+    protected $endroid5 = false;
+
     public function __construct($bgcolor = 'ffffff', $color = '000000', $margin = 0, $errorcorrectionlevel = 'H')
     {
         $this->endroid4 = method_exists(QrCode::class, 'create');
+        $this->endroid5 = enum_exists(ErrorCorrectionLevel::class);
 
         $this->bgcolor = $this->handleColor($bgcolor);
         $this->color = $this->handleColor($color);
@@ -76,11 +79,30 @@ class EndroidQrCodeProvider implements IQRCodeProvider
 
     private function handleErrorCorrectionLevel(string $level): ErrorCorrectionLevelInterface|ErrorCorrectionLevel
     {
+        if ($this->endroid4) {
+            return match ($level) {
+                'L' => new ErrorCorrectionLevelLow(),
+                'M' => new ErrorCorrectionLevelMedium(),
+                'Q' => new ErrorCorrectionLevelQuartile(),
+                default => new ErrorCorrectionLevelHigh(),
+            };
+        }
+
+        if ($this->endroid5) {
+            return match ($level) {
+                'L' => ErrorCorrectionLevel::Low,
+                'M' => ErrorCorrectionLevel::Medium,
+                'Q' => ErrorCorrectionLevel::Quartile,
+                default => ErrorCorrectionLevel::High,
+            };
+        }
+
+        // Assuming this is for version EndroidQR < 4
         return match ($level) {
-            'L' => $this->endroid4 ? new ErrorCorrectionLevelLow() : ErrorCorrectionLevel::LOW(),
-            'M' => $this->endroid4 ? new ErrorCorrectionLevelMedium() : ErrorCorrectionLevel::MEDIUM(),
-            'Q' => $this->endroid4 ? new ErrorCorrectionLevelQuartile() : ErrorCorrectionLevel::QUARTILE(),
-            default => $this->endroid4 ? new ErrorCorrectionLevelHigh() : ErrorCorrectionLevel::HIGH(),
+            'L' => ErrorCorrectionLevel::LOW(),
+            'M' => ErrorCorrectionLevel::MEDIUM(),
+            'Q' => ErrorCorrectionLevel::QUARTILE(),
+            default => ErrorCorrectionLevel::HIGH(),
         };
     }
 }

--- a/lib/Providers/Qr/EndroidQrCodeProvider.php
+++ b/lib/Providers/Qr/EndroidQrCodeProvider.php
@@ -79,15 +79,7 @@ class EndroidQrCodeProvider implements IQRCodeProvider
 
     private function handleErrorCorrectionLevel(string $level): ErrorCorrectionLevelInterface|ErrorCorrectionLevel
     {
-        if ($this->endroid4) {
-            return match ($level) {
-                'L' => new ErrorCorrectionLevelLow(),
-                'M' => new ErrorCorrectionLevelMedium(),
-                'Q' => new ErrorCorrectionLevelQuartile(),
-                default => new ErrorCorrectionLevelHigh(),
-            };
-        }
-
+        // First check for version 5 (using consts)
         if ($this->endroid5) {
             return match ($level) {
                 'L' => ErrorCorrectionLevel::Low,
@@ -97,7 +89,17 @@ class EndroidQrCodeProvider implements IQRCodeProvider
             };
         }
 
-        // Assuming this is for version EndroidQR < 4
+        // If not check for version 4 (using classes)
+        if ($this->endroid4) {
+            return match ($level) {
+                'L' => new ErrorCorrectionLevelLow(),
+                'M' => new ErrorCorrectionLevelMedium(),
+                'Q' => new ErrorCorrectionLevelQuartile(),
+                default => new ErrorCorrectionLevelHigh(),
+            };
+        }
+
+        // Any other version will be using strings
         return match ($level) {
             'L' => ErrorCorrectionLevel::LOW(),
             'M' => ErrorCorrectionLevel::MEDIUM(),

--- a/lib/Providers/Qr/EndroidQrCodeProvider.php
+++ b/lib/Providers/Qr/EndroidQrCodeProvider.php
@@ -79,7 +79,7 @@ class EndroidQrCodeProvider implements IQRCodeProvider
 
     private function handleErrorCorrectionLevel(string $level): ErrorCorrectionLevelInterface|ErrorCorrectionLevel
     {
-        // First check for version 5 (using consts)
+        // First check for version 5 (using enums)
         if ($this->endroid5) {
             return match ($level) {
                 'L' => ErrorCorrectionLevel::Low,


### PR DESCRIPTION
The new version is using PHP ENUMs, added a check to make it compatible with v5.

Should also still work for v4 (and older)!

Tested with `endroid/qr-code` v4.8.5 and v5.0.2 with both versions I can generate a QR code.

```
            $qr_provider = new EndroidQrCodeProvider();
            $tfa = new TwoFactorAuth("xx", qrcodeprovider: $qr_provider);
            $qr = $tfa->getQRCodeImageAsDataUri("uid", $secret);
```