### PR TITLE
Bacon has multiple versions now

### DIFF
--- a/.github/workflows/test-bacon.yml
+++ b/.github/workflows/test-bacon.yml
@@ -23,7 +23,7 @@ jobs:
         coverage: xdebug
         ini-values: error_reporting=E_ALL
 
-    - uses: ramsey/composer-install@v2
+    - uses: ramsey/composer-install@v3
 
     - run: composer require bacon/bacon-qr-code:${{ matrix.bacon-version }}
 

--- a/.github/workflows/test-bacon.yml
+++ b/.github/workflows/test-bacon.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.2', '8.3']
+        bacon-version: ['^2', '^3']
 
     steps:
     - uses: actions/checkout@v4
@@ -24,7 +25,7 @@ jobs:
 
     - uses: ramsey/composer-install@v2
 
-    - run: composer require bacon/bacon-qr-code
+    - run: composer require bacon/bacon-qr-code:${{ matrix.bacon-version }}
 
     - run: composer lint-ci
     - run: composer test testsDependency/BaconQRCodeTest.php

--- a/.github/workflows/test-endroid.yml
+++ b/.github/workflows/test-endroid.yml
@@ -23,7 +23,7 @@ jobs:
         coverage: xdebug
         ini-values: error_reporting=E_ALL
 
-    - uses: ramsey/composer-install@v2
+    - uses: ramsey/composer-install@v3
 
     - run: composer require endroid/qrcode:${{ matrix.endroid-version }} -W
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         coverage: xdebug
         ini-values: error_reporting=E_ALL
 
-    - uses: ramsey/composer-install@v2
+    - uses: ramsey/composer-install@v3
 
     - run: composer lint-ci
     - run: composer phpstan


### PR DESCRIPTION
Bacon QR code released a new major version out of nowhere and I almost missed it so I updated the workflow to deal with both.

Also apparently the Composer-installing workflow needed an update to get rid of an old version of Node.

Dropping PHP 8.1 made this easier as it is not supported by the latest version apparently (hat tip @NicolasCARPi)