### PR TITLE
set verify ssl parameter for HTTP based QR provider to true by default

### DIFF
--- a/docs/qr-codes/image-charts.md
+++ b/docs/qr-codes/image-charts.md
@@ -7,7 +7,7 @@ title: Image-Charts
 
 Argument                | Default value
 ------------------------|---------------
-`$verifyssl`            | `false`
+`$verifyssl`            | `true`
 `$errorcorrectionlevel` | `'L'`
 `$margin`               | `4`
 

--- a/docs/qr-codes/qr-server.md
+++ b/docs/qr-codes/qr-server.md
@@ -7,7 +7,7 @@ title: QR Server
 
 Argument                | Default value
 ------------------------|---------------
-`$verifyssl`            | `false`
+`$verifyssl`            | `true`
 `$errorcorrectionlevel` | `'L'`
 `$margin`               | `4`
 `$qzone`                | `1`

--- a/lib/Providers/Qr/BaseHTTPQRCodeProvider.php
+++ b/lib/Providers/Qr/BaseHTTPQRCodeProvider.php
@@ -6,7 +6,7 @@ namespace RobThree\Auth\Providers\Qr;
 
 abstract class BaseHTTPQRCodeProvider implements IQRCodeProvider
 {
-    protected bool $verifyssl;
+    protected bool $verifyssl = true;
 
     protected function getContent(string $url): string|bool
     {

--- a/lib/Providers/Qr/GoogleChartsQrCodeProvider.php
+++ b/lib/Providers/Qr/GoogleChartsQrCodeProvider.php
@@ -7,7 +7,7 @@ namespace RobThree\Auth\Providers\Qr;
 // https://developers.google.com/chart/infographics/docs/qr_codes
 class GoogleChartsQrCodeProvider extends BaseHTTPQRCodeProvider
 {
-    public function __construct(protected bool $verifyssl = false, public string $errorcorrectionlevel = 'L', public int $margin = 4, public string $encoding = 'UTF-8')
+    public function __construct(protected bool $verifyssl = true, public string $errorcorrectionlevel = 'L', public int $margin = 4, public string $encoding = 'UTF-8')
     {
     }
 

--- a/lib/Providers/Qr/ImageChartsQRCodeProvider.php
+++ b/lib/Providers/Qr/ImageChartsQRCodeProvider.php
@@ -9,7 +9,7 @@ namespace RobThree\Auth\Providers\Qr;
  */
 class ImageChartsQRCodeProvider extends BaseHTTPQRCodeProvider
 {
-    public function __construct(protected bool $verifyssl = false, public string $errorcorrectionlevel = 'L', public int $margin = 1)
+    public function __construct(protected bool $verifyssl = true, public string $errorcorrectionlevel = 'L', public int $margin = 1)
     {
     }
 

--- a/lib/Providers/Qr/QRServerProvider.php
+++ b/lib/Providers/Qr/QRServerProvider.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace RobThree\Auth\Providers\Qr;
 
 /**
- * Use http://goqr.me/api/doc/create-qr-code/ to get QR code
+ * Use https://goqr.me/api/doc/create-qr-code/ to get QR code
  */
 class QRServerProvider extends BaseHTTPQRCodeProvider
 {
-    public function __construct(protected bool $verifyssl = false, public string $errorcorrectionlevel = 'L', public int $margin = 4, public int $qzone = 1, public string $bgcolor = 'ffffff', public string $color = '000000', public string $format = 'png')
+    public function __construct(protected bool $verifyssl = true, public string $errorcorrectionlevel = 'L', public int $margin = 4, public int $qzone = 1, public string $bgcolor = 'ffffff', public string $color = '000000', public string $format = 'png')
     {
     }
 

--- a/lib/Providers/Qr/QRicketProvider.php
+++ b/lib/Providers/Qr/QRicketProvider.php
@@ -9,9 +9,8 @@ namespace RobThree\Auth\Providers\Qr;
  */
 class QRicketProvider extends BaseHTTPQRCodeProvider
 {
-    public function __construct(public string $errorcorrectionlevel = 'L', public string $bgcolor = 'ffffff', public string $color = '000000', public string $format = 'p')
+    public function __construct(protected bool $verifyssl = true, public string $errorcorrectionlevel = 'L', public string $bgcolor = 'ffffff', public string $color = '000000', public string $format = 'p')
     {
-        $this->verifyssl = false;
     }
 
     public function getMimeType(): string


### PR DESCRIPTION
it's already bad to use an external provider, let's use the safest defaults at least