### PR TITLE
handle curl errors. fix #129

### DIFF
--- a/demo/demo.php
+++ b/demo/demo.php
@@ -12,7 +12,7 @@
             });
 
             // substitute your company or app name here
-            $tfa = new RobThree\Auth\TwoFactorAuth('RobThree TwoFactorAuth');
+            $tfa = new RobThree\Auth\TwoFactorAuth(new RobThree\Auth\Providers\Qr\QRServerProvider());
         ?>
         <li>First create a secret and associate it with a user</li>
         <?php

--- a/lib/Providers/Qr/BaseHTTPQRCodeProvider.php
+++ b/lib/Providers/Qr/BaseHTTPQRCodeProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace RobThree\Auth\Providers\Qr;
 
+use RobThree\Auth\TwoFactorAuthException;
+
 abstract class BaseHTTPQRCodeProvider implements IQRCodeProvider
 {
     protected bool $verifyssl = true;
@@ -22,6 +24,9 @@ abstract class BaseHTTPQRCodeProvider implements IQRCodeProvider
             CURLOPT_USERAGENT => 'TwoFactorAuth',
         ));
         $data = curl_exec($curlhandle);
+        if ($data === false) {
+            throw new TwoFactorAuthException(curl_error($curlhandle));
+        }
 
         curl_close($curlhandle);
         return $data;

--- a/lib/Providers/Qr/BaseHTTPQRCodeProvider.php
+++ b/lib/Providers/Qr/BaseHTTPQRCodeProvider.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace RobThree\Auth\Providers\Qr;
 
-use RobThree\Auth\TwoFactorAuthException;
-
 abstract class BaseHTTPQRCodeProvider implements IQRCodeProvider
 {
     protected bool $verifyssl = true;
 
-    protected function getContent(string $url): string|bool
+    protected function getContent(string $url): string
     {
         $curlhandle = curl_init();
 
@@ -25,7 +23,7 @@ abstract class BaseHTTPQRCodeProvider implements IQRCodeProvider
         ));
         $data = curl_exec($curlhandle);
         if ($data === false) {
-            throw new TwoFactorAuthException(curl_error($curlhandle));
+            throw new QRException(curl_error($curlhandle));
         }
 
         curl_close($curlhandle);


### PR DESCRIPTION
if curl fails for some reason to get a QR code from an external (http) provider, the app will throw a TwoFactorAuthException.

also fix the demo page with new constructor signature