### PR TITLE
add support for endroid/qr-code version 6

### DIFF
--- a/.github/workflows/test-endroid.yml
+++ b/.github/workflows/test-endroid.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.2', '8.3']
-        endroid-version: ["^3","^4","^5"]
+        endroid-version: ["^3","^4","^5","^6"]
 
     steps:
     - uses: actions/checkout@v4

--- a/lib/Providers/Qr/EndroidQrCodeProvider.php
+++ b/lib/Providers/Qr/EndroidQrCodeProvider.php
@@ -59,25 +59,25 @@ class EndroidQrCodeProvider implements IQRCodeProvider
 
     protected function qrCodeInstance(string $qrText, int $size): QrCode
     {
-        if (!$this->endroid6) {
-            $qrCode = new QrCode($qrText);
-            $qrCode->setSize($size);
-
-            $qrCode->setErrorCorrectionLevel($this->errorcorrectionlevel);
-            $qrCode->setMargin($this->margin);
-            $qrCode->setBackgroundColor($this->bgcolor);
-            $qrCode->setForegroundColor($this->color);
-            return $qrCode;
+        if ($this->endroid6) {
+            return new QrCode(
+                data: $qrText,
+                errorCorrectionLevel: $this->errorcorrectionlevel,
+                size: $size,
+                margin: $this->margin,
+                foregroundColor: $this->color,
+                backgroundColor: $this->bgcolor
+            );
         }
 
-        return new QrCode(
-            data: $qrText,
-            errorCorrectionLevel: $this->errorcorrectionlevel,
-            size: $size,
-            margin: $this->margin,
-            foregroundColor: $this->color,
-            backgroundColor: $this->bgcolor
-        );
+        $qrCode = new QrCode($qrText);
+        $qrCode->setSize($size);
+
+        $qrCode->setErrorCorrectionLevel($this->errorcorrectionlevel);
+        $qrCode->setMargin($this->margin);
+        $qrCode->setBackgroundColor($this->bgcolor);
+        $qrCode->setForegroundColor($this->color);
+        return $qrCode;
     }
 
     private function handleColor(string $color): Color|array

--- a/lib/Providers/Qr/EndroidQrCodeProvider.php
+++ b/lib/Providers/Qr/EndroidQrCodeProvider.php
@@ -28,10 +28,13 @@ class EndroidQrCodeProvider implements IQRCodeProvider
 
     protected $endroid5 = false;
 
+    protected $endroid6 = false;
+
     public function __construct($bgcolor = 'ffffff', $color = '000000', $margin = 0, $errorcorrectionlevel = 'H')
     {
-        $this->endroid4 = method_exists(QrCode::class, 'create');
         $this->endroid5 = enum_exists(ErrorCorrectionLevel::class);
+        $this->endroid6 = $this->endroid5 && !method_exists(QrCode::class, 'setSize');
+        $this->endroid4 = $this->endroid6 || method_exists(QrCode::class, 'create');
 
         $this->bgcolor = $this->handleColor($bgcolor);
         $this->color = $this->handleColor($color);
@@ -56,15 +59,25 @@ class EndroidQrCodeProvider implements IQRCodeProvider
 
     protected function qrCodeInstance(string $qrText, int $size): QrCode
     {
-        $qrCode = new QrCode($qrText);
-        $qrCode->setSize($size);
+        if (!$this->endroid6) {
+            $qrCode = new QrCode($qrText);
+            $qrCode->setSize($size);
 
-        $qrCode->setErrorCorrectionLevel($this->errorcorrectionlevel);
-        $qrCode->setMargin($this->margin);
-        $qrCode->setBackgroundColor($this->bgcolor);
-        $qrCode->setForegroundColor($this->color);
+            $qrCode->setErrorCorrectionLevel($this->errorcorrectionlevel);
+            $qrCode->setMargin($this->margin);
+            $qrCode->setBackgroundColor($this->bgcolor);
+            $qrCode->setForegroundColor($this->color);
+            return $qrCode;
+        }
 
-        return $qrCode;
+        return new QrCode(
+            data: $qrText,
+            errorCorrectionLevel: $this->errorcorrectionlevel,
+            size: $size,
+            margin: $this->margin,
+            foregroundColor: $this->color,
+            backgroundColor: $this->bgcolor
+        );
     }
 
     private function handleColor(string $color): Color|array


### PR DESCRIPTION
### Feature added

Updated EndroidQrCodeProvider to work with version 6 of optional endroid/qr-code repository. (Breaking change in dependency: setter methods removed in favor of more modern practice of passing properties to QrCode constructor)

### Testing

Confirmed that EndroidQRCodeTest passes with either version 5 or 6 of endroid/qr-code installed