### PR TITLE
EndroidQrCodeProvider: allow transparent for color

### DIFF
--- a/lib/Providers/Qr/EndroidQrCodeProvider.php
+++ b/lib/Providers/Qr/EndroidQrCodeProvider.php
@@ -82,6 +82,10 @@ class EndroidQrCodeProvider implements IQRCodeProvider
 
     private function handleColor(string $color): Color|array
     {
+        if ($color === 'transparent') {
+            return $this->endroid4 ? new Color(255, 255, 255, 127) : array('r' => 255, 'g' => 255, 'b' => 255, 'a' => 127);
+        }
+
         $split = str_split($color, 2);
         $r = hexdec($split[0]);
         $g = hexdec($split[1]);


### PR DESCRIPTION
This enables support for the EndroidQrCodeProvider to allow `transparent` to be passed for `color` or `bgcolor`.

It is useful for `bgcolor`, but probably not too much for `color`.
That could be restricted. However, I do not really think that is needed.