### PR TITLE
Deprecated function: Implicit conversion from float 1.0E+60 to int loses precision 

### DIFF
--- a/lib/TwoFactorAuth.php
+++ b/lib/TwoFactorAuth.php
@@ -76,7 +76,7 @@ class TwoFactorAuth
         $value = unpack('N', $hashpart);                                                   // Unpack binary value
         $value = $value[1] & 0x7FFFFFFF;                                                   // Drop MSB, keep only 31 bits
 
-        return str_pad((string)($value % 10 ** $this->digits), $this->digits, '0', STR_PAD_LEFT);
+        return str_pad(bcmod((string)$value, bcpow('10', (string)$this->digits)), $this->digits, '0', STR_PAD_LEFT);
     }
 
     /**


### PR DESCRIPTION
Implemented bcmath functions to deal with:

- DivisionByZeroError: Modulo by zero en RobThree\Auth\TwoFactorAuth->getCode() (line 78
- Deprecated function: Implicit conversion from float 1.0E+60 to int loses precision en RobThree\Auth\TwoFactorAuth->getCode() (line 78