### PR TITLE
Removed curl_close to avoid deprecation warning on PHP 8.5

### DIFF
--- a/lib/Providers/Qr/BaseHTTPQRCodeProvider.php
+++ b/lib/Providers/Qr/BaseHTTPQRCodeProvider.php
@@ -26,7 +26,6 @@ abstract class BaseHTTPQRCodeProvider implements IQRCodeProvider
             throw new QRException(curl_error($curlhandle));
         }
 
-        curl_close($curlhandle);
         return $data;
     }
 }


### PR DESCRIPTION
Removed curl_close that has no effect since PHP 8.0 to avoid deprecation warning on PHP 8.5