### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/test-bacon.yml
+++ b/.github/workflows/test-bacon.yml
@@ -12,6 +12,11 @@ jobs:
       matrix:
         php-version: [8.2, 8.3, 8.4, 8.5]
         bacon-version: ["^2", "^3"]
+        exclude:
+          - php-version: 8.4
+            bacon-version: "^2"
+          - php-version: 8.5
+            bacon-version: "^2"
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/test-bacon.yml
+++ b/.github/workflows/test-bacon.yml
@@ -10,11 +10,11 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.2', '8.3']
-        bacon-version: ['^2', '^3']
+        php-version: [8.2, 8.3, 8.4, 8.5]
+        bacon-version: ["^2", "^3"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: shivammathur/setup-php@v2
       with:

--- a/.github/workflows/test-endroid.yml
+++ b/.github/workflows/test-endroid.yml
@@ -12,6 +12,19 @@ jobs:
       matrix:
         php-version: [8.2, 8.3, 8.4, 8.5]
         endroid-version: ["^3", "^4", "^5", "^6"]
+        exclude:
+          - php-version: 8.4
+            endroid-version: "^3"
+          - php-version: 8.4
+            endroid-version: "^4"
+          - php-version: 8.4
+            endroid-version: "^5"
+          - php-version: 8.5
+            endroid-version: "^3"
+          - php-version: 8.5
+            endroid-version: "^4"
+          - php-version: 8.5
+            endroid-version: "^5"
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/test-endroid.yml
+++ b/.github/workflows/test-endroid.yml
@@ -10,11 +10,11 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.2', '8.3']
-        endroid-version: ["^3","^4","^5","^6"]
+        php-version: [8.2, 8.3, 8.4, 8.5]
+        endroid-version: ["^3", "^4", "^5", "^6"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: shivammathur/setup-php@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.2', '8.3']
+        php-version: [8.2, 8.3, 8.4, 8.5]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: shivammathur/setup-php@v2
       with:


### PR DESCRIPTION
Been a while since we added new PHP versions to the workflows, had to go on a bit of a journey to exclude older versions which don't pass PHP 8.4 deprecations.